### PR TITLE
Chore: Nice exception messages

### DIFF
--- a/src/Asset/EntrypointLookup.php
+++ b/src/Asset/EntrypointLookup.php
@@ -102,21 +102,21 @@ class EntrypointLookup implements EntrypointLookupInterface
         }
 
         if (!file_exists($this->getEntrypointJsonPath())) {
-            throw new \InvalidArgumentException(sprintf('Could not find the entrypoints file from Webpack: the file "%s" does not exist.', $this->getEntrypointJsonPath()));
+            throw new \InvalidArgumentException(sprintf('Could not find the entrypoints file from Webpack: the file "%s" does not exist. Maybe you forgot to run npm/yarn build?', $this->getEntrypointJsonPath()));
         }
 
         try {
             $entriesData = $this->decoder->decode(file_get_contents($this->getEntrypointJsonPath()), JsonEncoder::FORMAT);
         } catch (UnexpectedValueException $e) {
-            throw new \InvalidArgumentException(sprintf('There was a problem JSON decoding the "%s" file', $this->getEntrypointJsonPath()), 0, $e);
+            throw new \InvalidArgumentException(sprintf('There was a problem JSON decoding the "%s" file. Try to run npm/yarn build to fix the issue.', $this->getEntrypointJsonPath()), 0, $e);
         }
 
         if (!\is_array($entriesData)) {
-            throw new \InvalidArgumentException(sprintf('There was a problem JSON decoding the "%s" file', $this->getEntrypointJsonPath()));
+            throw new \InvalidArgumentException(sprintf('There was a problem JSON decoding the "%s" file. Try to run npm/yarn build to fix the issue.', $this->getEntrypointJsonPath()));
         }
 
         if (!isset($entriesData['entrypoints'])) {
-            throw new \InvalidArgumentException(sprintf('Could not find an "entrypoints" key in the "%s" file', $this->getEntrypointJsonPath()));
+            throw new \InvalidArgumentException(sprintf('Could not find an "entrypoints" key in the "%s" file. Try to run npm/yarn build to fix the issue.', $this->getEntrypointJsonPath()));
         }
 
         return $this->entriesData = $entriesData;

--- a/tests/unit/Asset/EntrypointLookupTest.php
+++ b/tests/unit/Asset/EntrypointLookupTest.php
@@ -277,25 +277,25 @@ class EntrypointLookupTest extends TestCase
         return [
             [
                 'entrypointFilePath' => '/../fixtures/bad_json',
-                'expectedExceptionMessageMatches' => '/There was a problem JSON decoding the ".*\/fixtures\/bad_json\/entrypoints.json" file/',
+                'expectedExceptionMessageMatches' => '/There was a problem JSON decoding the ".*\/fixtures\/bad_json\/entrypoints.json" file\. Try to run npm\/yarn build to fix the issue\./',
                 'expectedJson' => file_get_contents(__DIR__.'/../fixtures/bad_json/entrypoints.json'),
                 'decodedJson' => null,
             ],
             [
                 'entrypointFilePath' => '/../fixtures/no_entrypoint_key',
-                'expectedExceptionMessageMatches' => '/Could not find an "entrypoints" key in the ".*\/fixtures\/no_entrypoint_key\/entrypoints.json" file/',
+                'expectedExceptionMessageMatches' => '/Could not find an "entrypoints" key in the ".*\/fixtures\/no_entrypoint_key\/entrypoints.json" file\. Try to run npm\/yarn build to fix the issue\./',
                 'expectedJson' => file_get_contents(__DIR__.'/../fixtures/no_entrypoint_key/entrypoints.json'),
                 'decodedJson' => ['entrypoint' => []],
             ],
             [
                 'entrypointFilePath' => '/../fixtures/no_file',
-                'expectedExceptionMessageMatches' => '/Could not find the entrypoints file from Webpack: the file ".*\/fixtures\/no_file\/entrypoints.json" does not exist\./',
+                'expectedExceptionMessageMatches' => '/Could not find the entrypoints file from Webpack: the file ".*\/fixtures\/no_file\/entrypoints.json" does not exist\. Maybe you forgot to run npm\/yarn build?/',
                 'expectedJson' => '',
                 'decodedJson' => null,
             ],
             [
                 'entrypointFilePath' => '/../fixtures/bad_json',
-                'expectedExceptionMessageMatches' => '/There was a problem JSON decoding the ".*" file/',
+                'expectedExceptionMessageMatches' => '/There was a problem JSON decoding the ".*" file\. Try to run npm\/yarn build to fix the issue\./',
                 'expectedJson' => file_get_contents(__DIR__.'/../fixtures/bad_json/entrypoints.json'),
                 'decodedJson' => null,
             ],


### PR DESCRIPTION
- Added a nice message for some exceptions where the user might have forgotten to run npm/yarn build command (e.g. entrypoints.json file is missing, bad json file or else);